### PR TITLE
View-transition feature

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="view-transition" content="same-origin" />
     <title>Red Balloon</title>
     <link
       rel="icon"


### PR DESCRIPTION
Hi all. By adding a 'view-transition' meta tag, it creates a neat transition feature globally throughout the entire app. Unfortunately, its a very new feature that needs to be enabled on the canary build of chrome, or the arc browser. For every other browser, it is ignored...for now. We can build it out to add more interesting effects, but I just wanted to slip it in in the meantime. For reference: https://daverupert.com/2023/05/getting-started-view-transitions/.